### PR TITLE
Remove circular references in named arguments

### DIFF
--- a/lib/samwise/client.rb
+++ b/lib/samwise/client.rb
@@ -3,23 +3,23 @@ require 'json'
 
 module Samwise
   class Client
-    def initialize(api_key: api_key)
+    def initialize(api_key:)
       @api_key = api_key || ENV['DATA_DOT_GOV_API_KEY']
     end
 
-    def get_duns_info(duns: nil)
+    def get_duns_info(duns:)
       response = lookup_duns(duns: duns)
       JSON.parse(response.body)
     end
 
-    def duns_is_valid?(duns: nil)
+    def duns_is_valid?(duns:)
       response = lookup_duns(duns: duns)
       response.status == 200
     end
 
     private
 
-    def lookup_duns(duns: duns)
+    def lookup_duns(duns:)
       duns = Samwise::Util.format_duns(duns: duns)
       response = Faraday.get(Samwise::Protocol.duns_url(duns: duns, api_key: @api_key))
     end

--- a/lib/samwise/protocol.rb
+++ b/lib/samwise/protocol.rb
@@ -3,7 +3,7 @@ module Samwise
     BASE_URL = "https://api.data.gov"
     API_VERSION = "v1"
 
-    def self.duns_url(duns: duns, api_key: api_key)
+    def self.duns_url(duns:, api_key:)
       "#{BASE_URL}/sam/#{API_VERSION}/registrations/#{duns}?api_key=#{api_key}"
     end
   end

--- a/lib/samwise/util.rb
+++ b/lib/samwise/util.rb
@@ -2,7 +2,7 @@ require 'pry'
 
 module Samwise
   module Util
-    def self.format_duns(duns: duns)
+    def self.format_duns(duns:)
       if duns.length == 9
         duns = "#{duns}0000"
       elsif duns.length == 8

--- a/lib/samwise/version.rb
+++ b/lib/samwise/version.rb
@@ -1,4 +1,4 @@
 module Samwise
   # samwise version
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,6 +9,8 @@ describe Samwise::Client, vcr: { cassette_name: "Samwise::Client", record: :new_
   let(:non_existent_duns) { '0000001000000' }
 
   context '#duns_is_valid?' do
+    before(:all) { ENV['DATA_DOT_GOV_API_KEY'] = 'fakeapikey' }
+    
     it "should verify that a 9 digit DUNS number exists" do
       client = Samwise::Client.new(api_key: api_key)
       response = client.duns_is_valid?(duns: nine_duns)


### PR DESCRIPTION
This was causing some warnings downstream. Also, I fixed it so the tests will work even if I don't have the ENV API key set
