### PR TITLE
Bump to version 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ Samwise::Util.format_duns(duns: '08-011-5718')
 - If it is 9 digits, `0000` is added to the end.
 - If it is 13 digits, the number is unchanged.
 
+### Check status in SAM.gov
+
+There is a web form where anyone can enter a DUNS number to get its status within SAM.gov: https://www.sam.gov/sam/helpPage/SAM_Reg_Status_Help_Page.html.
+
+This form uses an undocumented/unpublished JSON endpoint. This gem provides Ruby access to that endpoint.
+
+This does not require an api.data.gov API key, but it will make a network call to the above URL.
+
+The SAM.gov status web form hard codes what appears to be an API key. That key is used by default in this gem. However, you may supply your own (also tell us where you got it!).
+
+```ruby
+client = Samwise::Client.new(sam_status_key:  'optional')
+client.get_sam_status(duns: '08-011-5718')
+
+#=> {
+  "Message" => "Request for registration information forbidden",
+  "Code" => 403,
+  "Error" => ""
+}
+
+client.get_sam_status(duns: )
+```
+
 ## Install
 
 In your Gemfile:

--- a/lib/samwise/protocol.rb
+++ b/lib/samwise/protocol.rb
@@ -1,10 +1,22 @@
 module Samwise
   module Protocol
-    BASE_URL = "https://api.data.gov"
-    API_VERSION = "v1"
+    SAM_API_BASE_URL    = 'https://api.data.gov'
+    SAM_API_API_VERSION = 'v1'
+    SAM_STATUS_URL      = 'https://www.sam.gov/samdata/registrations/trackProgress'
+    SAM_STATUS_KEY      = '1452031543862'
 
-    def self.duns_url(duns: duns, api_key: api_key)
-      "#{BASE_URL}/sam/#{API_VERSION}/registrations/#{duns}?api_key=#{api_key}"
+    def self.duns_url(duns: nil, api_key: nil)
+      fail Samwise::Error::ArgumentMissing, 'DUNS number is missing' if duns.nil?
+      fail Samwise::Error::ArgumentMissing, 'SAM.gov API key is missing' if api_key.nil?
+
+      "#{SAM_API_BASE_URL}/sam/#{SAM_API_API_VERSION}/registrations/#{duns}?api_key=#{api_key}"
+    end
+
+    def self.sam_status_url(duns: nil, api_key: nil)
+      fail Samwise::Error::ArgumentMissing, 'DUNS number is missing' if duns.nil?
+      fail Samwise::Error::ArgumentMissing, 'SAM status key is missing' if api_key.nil?
+
+      "#{SAM_STATUS_URL}/?duns=#{duns}&_=#{api_key}"
     end
   end
 end

--- a/lib/samwise/version.rb
+++ b/lib/samwise/version.rb
@@ -1,3 +1,3 @@
 module Samwise
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/samwise.gemspec
+++ b/samwise.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'webmock'
 
+  gem.add_runtime_dependency 'httpclient'
   gem.add_runtime_dependency 'faraday'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -6,66 +6,113 @@ describe Samwise::Client, vcr: { cassette_name: "Samwise::Client", record: :new_
   let(:nine_duns)         { '809102507' }
   let(:eight_duns)        { '78327018' }
   let(:thirteen_duns)     { '0223841150000' }
+  let(:not_in_sam_duns)   { '08-011-5718' }
+  let(:valid_dunses)      { [nine_duns, eight_duns, thirteen_duns] }
   let(:non_existent_duns) { '0000001000000' }
+  let(:client)            { Samwise::Client.new(api_key: api_key) }
+  let(:bad_dunses) do
+    [
+      '1234567890',
+      '12345678901',
+      '123456789011',
+      '1',
+      '',
+      '--',
+      '12345678901234567890'
+    ]
+  end
+
+  context '#get_sam_status' do
+    it 'should return a Hash given a valid DUNS number' do
+      skip 'until SSL issues can be addressed'
+      valid_dunses.each do |valid_duns|
+        expect(client.get_sam_status(duns: valid_duns)).to be_a(Hash)
+      end
+    end
+
+    it 'should return a Hash given a DUNS not in SAM' do
+      skip 'until SSL issues can be addressed'
+      expect(client.get_sam_status(duns: not_in_sam_duns)).to be_a(Hash)
+    end
+
+    it 'should raise a Samwise::Error::InvalidFormat error given an invalid DUNS number' do
+      bad_dunses.each do |bad_duns|
+        expect do
+          client.get_sam_status(duns: bad_duns)
+        end.to raise_error(Samwise::Error::InvalidFormat)
+      end
+    end
+
+  end
 
   context '#duns_is_in_sam?' do
     it "should verify that a 9 digit DUNS number exists in sam.gov" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.duns_is_in_sam?(duns: nine_duns)
 
       expect(response).to be(true)
     end
 
     it "should verify that an 8 digit DUNS number exists in sam.gov" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.duns_is_in_sam?(duns: eight_duns)
 
       expect(response).to be(true)
     end
 
     it "should verify that a 13 digit DUNS number exists in sam.gov" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.duns_is_in_sam?(duns: thirteen_duns)
 
       expect(response).to be(true)
     end
 
     it "should return false given a DUNS number that is not in sam.gov" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.duns_is_in_sam?(duns: non_existent_duns)
 
       expect(response).to be(false)
     end
+
+    it 'should raise a Samwise::Error::InvalidFormat error given an invalid DUNS number' do
+      bad_dunses.each do |bad_duns|
+        expect do
+          client.duns_is_in_sam?(duns: bad_duns)
+        end.to raise_error(Samwise::Error::InvalidFormat)
+      end
+    end
+
   end
 
   context '#get_duns_info' do
     it "should get info for a 9 digit DUNS number" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.get_duns_info(duns: nine_duns)
 
       expect(response).to be_a(Hash)
     end
 
     it "should get info for an 8 digit DUNS number" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.get_duns_info(duns: eight_duns)
 
       expect(response).to be_a(Hash)
     end
 
     it "should get info for a 13 digit DUNS number" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.get_duns_info(duns: thirteen_duns)
 
       expect(response).to be_a(Hash)
     end
 
     it "should return an error given a DUNS number that is not in sam.gov" do
-      client = Samwise::Client.new(api_key: api_key)
       response = client.get_duns_info(duns: non_existent_duns)
 
       expect(response).to be_a(Hash)
       expect(response['Error']).to eq('Not Found')
     end
+
+    it 'should raise a Samwise::Error::InvalidFormat error given an invalid DUNS number' do
+      bad_dunses.each do |bad_duns|
+        expect do
+          client.get_duns_info(duns: bad_duns)
+        end.to raise_error(Samwise::Error::InvalidFormat)
+      end
+    end
+
   end
 end

--- a/spec/vcr/Samwise_Client.yml
+++ b/spec/vcr/Samwise_Client.yml
@@ -2,197 +2,17 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.data.gov/sam/v1/registrations/8091025070000?api_key=
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 29 Dec 2015 22:10:13 GMT
-      Server:
-      - openresty
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - MISS
-      Content-Length:
-      - '132'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "error": {
-            "code": "API_KEY_MISSING",
-            "message": "No api_key was supplied. Get one at https://api.data.gov"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:10:13 GMT
-- request:
-    method: get
-    uri: https://api.data.gov/sam/v1/registrations/0783270180000?api_key=
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 29 Dec 2015 22:10:13 GMT
-      Server:
-      - openresty
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - MISS
-      Content-Length:
-      - '132'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "error": {
-            "code": "API_KEY_MISSING",
-            "message": "No api_key was supplied. Get one at https://api.data.gov"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:10:13 GMT
-- request:
-    method: get
-    uri: https://api.data.gov/sam/v1/registrations/0223841150000?api_key=
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 29 Dec 2015 22:10:13 GMT
-      Server:
-      - openresty
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - MISS
-      Content-Length:
-      - '132'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "error": {
-            "code": "API_KEY_MISSING",
-            "message": "No api_key was supplied. Get one at https://api.data.gov"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:10:13 GMT
-- request:
-    method: get
-    uri: https://api.data.gov/sam/v1/registrations/0000001000000?api_key=
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 29 Dec 2015 22:10:13 GMT
-      Server:
-      - openresty
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - MISS
-      Content-Length:
-      - '132'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "error": {
-            "code": "API_KEY_MISSING",
-            "message": "No api_key was supplied. Get one at https://api.data.gov"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:10:13 GMT
-- request:
-    method: get
     uri: https://api.data.gov/sam/v1/registrations/8091025070000?api_key=<data_dot_gov_api_key>
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      - HTTPClient/1.0 (2.7.1, ruby 2.1.5 (2014-11-13))
       Accept:
       - "*/*"
+      Date:
+      - Wed, 06 Jan 2016 20:01:33 GMT
   response:
     status:
       code: 200
@@ -203,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 29 Dec 2015 22:17:51 GMT
+      - Wed, 06 Jan 2016 20:01:15 GMT
       Server:
       - openresty
       Vary:
@@ -216,9 +36,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4896'
-      Content-Length:
-      - '1418'
+      - '4989'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -227,7 +47,7 @@ http_interactions:
         Pebble Hill Lane","Zip":"20878","Country":"USA","City":"North Potomac","stateorProvince":"MD"},"email":"VIJAY@XFINION.COM","usPhone":"3018014897","firstName":"VIJAY"},"disasterRelief":{"type":"ANY"},"dunsPlus4":"0000","activationDate":"2015-11-27
         08:50:04.0","fiscalYearEndCloseDate":"12/31","businessTypes":["QZ","XS","VW","2X","27","23","A620240406"],"pastPerformancePoc":{"lastName":"MECCIA","address":{"Line1":"600
         19th St NW","Zip":"20431","Country":"USA","City":"Washington","stateorProvince":"DC"},"email":"MECCIAMJ@STATE.GOV","usPhone":"2024857820","firstName":"MICHAEL"},"registrationDate":"2008-08-17
-        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=O65Y2vmSLpZC4QP4%2BMYzVdllJhATH31debEqvUb628jK%2Fu9HCIEHRWq%2BOqN8aTgg&pitId=Aq3b8eh7ABQZTfXMApF6SUfR3zpdw7Bn9vwi6ups0%2B%2Fqd0prdUwoqKN7zaWmcfgazvC0p%2BU2El%2BE%0AfW%2Fx2e4aQg%3D%3D&requestId=P9mf7IA81Q1zAn7"},"hasDelinquentFederalDebt":false,"duns":"809102507","altElectronicBusinessPoc":{"lastName":"GOSWAMI","fax":"8665667533","address":{"Line1":"14608
+        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=Zy7Pcr575TOozBfu0s2bViB2r%2Fqmw9Wg4JnFzpkZdsJ0HdXjYehmDrcFO9RnNaRq&pitId=xoejtS%2BtlcEa10di8z3oi0tTzy27POa44TCS3cahAyXpyvmNc6Euwh%2FQtanSvmjHs7s5dvrvXmi9%0Ayo6oUedZdg%3D%3D&requestId=oPCyK98P2qU08Ci"},"hasDelinquentFederalDebt":false,"duns":"809102507","altElectronicBusinessPoc":{"lastName":"GOSWAMI","fax":"8665667533","address":{"Line1":"14608
         Pebble Hill Lnae","Zip":"20878","Country":"USA","City":"North Potomac","stateorProvince":"MD"},"email":"NILAM@XFINION.COM","usPhone":"3013286579","firstName":"NILAM"},"cage":"561R4","hasKnownExclusion":false,"publicDisplay":true,"expirationDate":"2016-11-25
         18:48:10.0","altPastPerformancePoc":{"lastName":"KAUL","address":{"Line1":"1801
         North Lynn Street","Zip":"22209","Country":"USA","City":"Rosslyn","stateorProvince":"VA"},"email":"KAULN@STATE.GOV","usPhone":"5713459854","firstName":"NISHA"},"status":"ACTIVE","corporateStructureCode":"2L","corporateStructureName":"Corporate
@@ -245,88 +65,20 @@ http_interactions:
         Pebble Hill Lane","Zip":"20878","Country":"USA","City":"North Potomac","stateorProvince":"MD"},"email":"VIJAY@XFINION.COM","usPhone":"3018014897","firstName":"VIJAY"},"mailingAddress":{"Line1":"7800
         lonesome pine ln","Zip":"20817","Country":"USA","City":"Bethesda","stateorProvince":"MD"},"purposeOfRegistration":"ALL_AWARDS"}}}'
     http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:17:53 GMT
+  recorded_at: Wed, 06 Jan 2016 20:01:34 GMT
 - request:
     method: get
     uri: https://api.data.gov/sam/v1/registrations/0783270180000?api_key=<data_dot_gov_api_key>
     body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Age:
-      - '1'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 29 Dec 2015 22:17:52 GMT
-      Server:
-      - openresty
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding
-      Via:
-      - http/1.1 api-umbrella (ApacheTrafficServer [cMsSf ])
-      X-Cache:
-      - MISS
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4896'
-      Content-Length:
-      - '1291'
-      Connection:
-      - keep-alive
-    body:
       encoding: UTF-8
-      string: '{"sam_data":{"registration":{"govtBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
-        ENGINEER","fax":"9787766968","address":{"Zip4":"2799","Line1":"328 VIRGINIA
-        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MCR@ISLANDPEAKSOFTWARE.COM","middleInitial":"C","usPhone":"9783418385","firstName":"MARK"},"dunsPlus4":"0000","activationDate":"2015-03-29
-        15:45:03.0","fiscalYearEndCloseDate":"12/31","businessTypes":["LJ","VW","2X"],"registrationDate":"2011-12-27
-        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=PCNW16NzwdnjzNB13TIio6hBdFa276W51xGsyOBYiX5GrgJhThLYvSugeesI1aM5&pitId=vrKqyyTxwFcjJPaAu8Bcazbrc6%2FLIKDcXdWzvDKgMUOeq7oomukW5jpIIoQzZn9cfexZNKqetCEm%0AlF%2FF0MhB8g%3D%3D&requestId=zU8Lj4quyxXZC4X"},"pscCodes":[{"pscName":"R&D-
-        GENERAL SCIENCE/TECHNOLOGY: MATHEMATICAL/COMPUTER SCIENCES (BASIC RESEARCH)","pscCode":"AJ21"},{"pscName":"R&D-
-        GENERAL SCIENCE/TECHNOLOGY: MATHEMATICAL/COMPUTER SCIENCES (APPLIED RESEARCH/EXPLORATORY
-        DEVELOPMENT)","pscCode":"AJ22"},{"pscName":"R&D- GENERAL SCIENCE/TECHNOLOGY:
-        MATHEMATICAL/COMPUTER SCIENCES (ADVANCED DEVELOPMENT)","pscCode":"AJ23"}],"hasDelinquentFederalDebt":false,"duns":"078327018","cage":"6M6Y4","altElectronicBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
-        ENGINEER","fax":"9783710046","address":{"Zip4":"2799","Line1":"328 VIRGINIA
-        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MARKCREYNOLDS@COMCAST.NET","middleInitial":"C","usPhone":"9783710046","firstName":"MARK"},"hasKnownExclusion":false,"publicDisplay":true,"expirationDate":"2016-03-28
-        15:35:18.0","status":"ACTIVE","corporateStructureCode":"2K","stateOfIncorporation":"MA","corporateStructureName":"Partnership
-        or Limited Liability Partnership","legalBusinessName":"ISLAND PEAK SOFTWARE
-        LLC","congressionalDistrict":"MA 03","businessStartDate":"2011-11-30","statusMessage":"Active","lastUpdateDate":"2015-03-30
-        16:16:49.0","samAddress":{"Zip4":"2799","Line1":"328 VIRGINIA RD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"submissionDate":"2015-03-29
-        15:35:18.0","naics":[{"isPrimary":true,"naicsCode":"541712","naicsName":"RESEARCH
-        AND DEVELOPMENT IN THE PHYSICAL, ENGINEERING, AND LIFE SCIENCES (EXCEPT BIOTECHNOLOGY)"},{"isPrimary":false,"naicsCode":"541511","naicsName":"CUSTOM
-        COMPUTER PROGRAMMING SERVICES"}],"corporateUrl":"www.islandpeaksoftware.com","altGovtBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
-        ENGINEER","fax":"9783710046","address":{"Zip4":"2799","Line1":"328 VIRGINIA
-        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MARKCREYNOLDS@COMCAST.NET","middleInitial":"C","usPhone":"9783710046","firstName":"MARK"},"creditCardUsage":false,"countryOfIncorporation":"USA","electronicBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
-        ENGINEER","fax":"9787766968","address":{"Zip4":"2799","Line1":"328 VIRGINIA
-        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MCR@ISLANDPEAKSOFTWARE.COM","middleInitial":"C","usPhone":"9783418385","firstName":"MARK"},"mailingAddress":{"Zip4":"2799","Line1":"328
-        VIRGINIA ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"purposeOfRegistration":"ALL_AWARDS"}}}'
-    http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:17:53 GMT
-- request:
-    method: get
-    uri: https://api.data.gov/sam/v1/registrations/0223841150000?api_key=<data_dot_gov_api_key>
-    body:
-      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      - HTTPClient/1.0 (2.7.1, ruby 2.1.5 (2014-11-13))
       Accept:
       - "*/*"
+      Date:
+      - Wed, 06 Jan 2016 20:01:34 GMT
   response:
     status:
       code: 200
@@ -337,7 +89,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 29 Dec 2015 22:17:52 GMT
+      - Wed, 06 Jan 2016 20:01:15 GMT
       Server:
       - openresty
       Vary:
@@ -350,9 +102,77 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4893'
+      - '4988'
       Content-Length:
-      - '1998'
+      - '3299'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"sam_data":{"registration":{"govtBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
+        ENGINEER","fax":"9787766968","address":{"Zip4":"2799","Line1":"328 VIRGINIA
+        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MCR@ISLANDPEAKSOFTWARE.COM","middleInitial":"C","usPhone":"9783418385","firstName":"MARK"},"dunsPlus4":"0000","activationDate":"2015-03-29
+        15:45:03.0","fiscalYearEndCloseDate":"12/31","businessTypes":["LJ","VW","2X"],"registrationDate":"2011-12-27
+        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=CfE3psUYW8AzBIo9heITds3s6uj94i4CpullWZgrnbXddF3C%2FdGuyS9YM7WmhMlG&pitId=0IE%2BOsh06%2BYELonwrXcthhdZyC9BxTkLT5yI0lhUz%2FmN%2BZrVPnRSXCuwxdmpz2NSnC%2BnPDNPQIgF%0AixZvwSdNnw%3D%3D&requestId=47sK8ymUj43UF54"},"pscCodes":[{"pscName":"R&D-
+        GENERAL SCIENCE/TECHNOLOGY: MATHEMATICAL/COMPUTER SCIENCES (BASIC RESEARCH)","pscCode":"AJ21"},{"pscName":"R&D-
+        GENERAL SCIENCE/TECHNOLOGY: MATHEMATICAL/COMPUTER SCIENCES (APPLIED RESEARCH/EXPLORATORY
+        DEVELOPMENT)","pscCode":"AJ22"},{"pscName":"R&D- GENERAL SCIENCE/TECHNOLOGY:
+        MATHEMATICAL/COMPUTER SCIENCES (ADVANCED DEVELOPMENT)","pscCode":"AJ23"}],"hasDelinquentFederalDebt":false,"duns":"078327018","cage":"6M6Y4","altElectronicBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
+        ENGINEER","fax":"9783710046","address":{"Zip4":"2799","Line1":"328 VIRGINIA
+        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MARKCREYNOLDS@COMCAST.NET","middleInitial":"C","usPhone":"9783710046","firstName":"MARK"},"hasKnownExclusion":false,"publicDisplay":true,"expirationDate":"2016-03-28
+        15:35:18.0","status":"ACTIVE","corporateStructureCode":"2K","stateOfIncorporation":"MA","corporateStructureName":"Partnership
+        or Limited Liability Partnership","legalBusinessName":"ISLAND PEAK SOFTWARE
+        LLC","congressionalDistrict":"MA 03","businessStartDate":"2011-11-30","statusMessage":"Active","lastUpdateDate":"2015-03-30
+        16:16:49.0","samAddress":{"Zip4":"2799","Line1":"328 VIRGINIA RD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"submissionDate":"2015-03-29
+        15:35:18.0","naics":[{"isPrimary":false,"naicsCode":"541511","naicsName":"CUSTOM
+        COMPUTER PROGRAMMING SERVICES"},{"isPrimary":true,"naicsCode":"541712","naicsName":"RESEARCH
+        AND DEVELOPMENT IN THE PHYSICAL, ENGINEERING, AND LIFE SCIENCES (EXCEPT BIOTECHNOLOGY)"}],"corporateUrl":"www.islandpeaksoftware.com","altGovtBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
+        ENGINEER","fax":"9783710046","address":{"Zip4":"2799","Line1":"328 VIRGINIA
+        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MARKCREYNOLDS@COMCAST.NET","middleInitial":"C","usPhone":"9783710046","firstName":"MARK"},"creditCardUsage":false,"countryOfIncorporation":"USA","electronicBusinessPoc":{"lastName":"REYNOLDS","title":"CHIEF
+        ENGINEER","fax":"9787766968","address":{"Zip4":"2799","Line1":"328 VIRGINIA
+        ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"email":"MCR@ISLANDPEAKSOFTWARE.COM","middleInitial":"C","usPhone":"9783418385","firstName":"MARK"},"mailingAddress":{"Zip4":"2799","Line1":"328
+        VIRGINIA ROAD","Zip":"01742","Country":"USA","City":"CONCORD","stateorProvince":"MA"},"purposeOfRegistration":"ALL_AWARDS"}}}'
+    http_version: 
+  recorded_at: Wed, 06 Jan 2016 20:01:34 GMT
+- request:
+    method: get
+    uri: https://api.data.gov/sam/v1/registrations/0223841150000?api_key=<data_dot_gov_api_key>
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.7.1, ruby 2.1.5 (2014-11-13))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 06 Jan 2016 20:01:34 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Age:
+      - '1'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 Jan 2016 20:01:16 GMT
+      Server:
+      - openresty
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Via:
+      - http/1.1 api-umbrella (ApacheTrafficServer [cMsSf ])
+      X-Cache:
+      - MISS
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4988'
+      Content-Length:
+      - '5615'
       Connection:
       - keep-alive
     body:
@@ -360,7 +180,7 @@ http_interactions:
       string: '{"sam_data":{"registration":{"govtBusinessPoc":{"lastName":"GREMILLION","usPhoneExt":"1112","fax":"5048311901","address":{"Line2":"STE.
         1600","Zip4":"3044","Line1":"111 VETERANS BLVD.","Zip":"70005","Country":"USA","City":"METAIRIE","stateorProvince":"LA"},"email":"RICK.GREMILLION@GEOCENT.COM","usPhone":"5048311900","firstName":"RICHARD"},"dunsPlus4":"0000","activationDate":"2015-08-06
         09:31:21.0","fiscalYearEndCloseDate":"12/31","businessTypes":["LJ","VW","2X"],"registrationDate":"2009-09-02
-        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=5ps2K%2BldaCjKxB%2FTvGDLIyaiIpbCniFyLbpC77HyKSsSkhOWIoVWJF6RD2arG%2Fvi&pitId=%2FIFf33A8ZMw%2FXmwjtmbRFjOcXSk4xYCMZc6KYCilw05vYIuqBvRqRx3Kq1SjcWeP&requestId=09YluCc9tJ6R14A"},"pscCodes":[{"pscName":"SUPPORT-
+        00:00:00.0","certificationsURL":{"pdfUrl":"https://www.sam.gov/SAMPortal/filedownload?reportType=2&orgId=A%2FGzJar8p9bfsUBQbehJcLa5Xg4YWxVDtDV4tT%2B3N0nDLP2sfKFewpoROGej2Das&pitId=94DUQxnau2ECyduTU9pec1ucWn25Y%2FDgj6qQOedZqs8cX1KMQ3L8LSXLHy4xkEcv&requestId=Fe7lHI9N0YwQ850"},"pscCodes":[{"pscName":"SUPPORT-
         PROFESSIONAL: PROGRAM MANAGEMENT/SUPPORT","pscCode":"R408"},{"pscName":"SUPPORT-
         PROFESSIONAL: PERSONAL SERVICES CONTRACTS","pscCode":"R497"},{"pscName":"SUPPORT-
         PROFESSIONAL: TECHNOLOGY SHARING/UTILIZATION","pscCode":"R415"},{"pscName":"SUPPORT-
@@ -403,20 +223,20 @@ http_interactions:
         1600","Zip4":"3044","Line1":"111 VETERANS BLVD.","Zip":"70005","Country":"USA","City":"METAIRIE","stateorProvince":"LA"},"email":"CONTRACTS@GEOCENT.COM","middleInitial":"S.","usPhone":"5048311900","firstName":"CATHERINE"},"mailingAddress":{"Line2":"Suite
         1600","Zip4":"3044","Line1":"111 VETERANS MEMORIAL BLVD","Zip":"70005","Country":"USA","City":"METAIRIE","stateorProvince":"LA"},"purposeOfRegistration":"ALL_AWARDS"}}}'
     http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:17:53 GMT
+  recorded_at: Wed, 06 Jan 2016 20:01:34 GMT
 - request:
     method: get
     uri: https://api.data.gov/sam/v1/registrations/0000001000000?api_key=<data_dot_gov_api_key>
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      - HTTPClient/1.0 (2.7.1, ruby 2.1.5 (2014-11-13))
       Accept:
       - "*/*"
+      Date:
+      - Wed, 06 Jan 2016 20:01:34 GMT
   response:
     status:
       code: 404
@@ -427,7 +247,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 29 Dec 2015 22:17:52 GMT
+      - Wed, 06 Jan 2016 20:01:16 GMT
       Server:
       - openresty
       Vary:
@@ -440,9 +260,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4895'
+      - '4986'
       Content-Length:
-      - '100'
+      - '80'
       Connection:
       - keep-alive
     body:
@@ -450,5 +270,5 @@ http_interactions:
       string: '{"Message":"The registration could not be found","Code":404,"Error":"Not
         Found"}'
     http_version: 
-  recorded_at: Tue, 29 Dec 2015 22:17:53 GMT
+  recorded_at: Wed, 06 Jan 2016 20:01:34 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Update VCR cassettes

Skipping SAM status specs until SSL issues fixed.

Updated VCR cassettes.

Removed circular argument reference in Protocol.
