### PR TITLE
Version 0.2.2

### DIFF
--- a/lib/samwise/util.rb
+++ b/lib/samwise/util.rb
@@ -3,6 +3,8 @@ require 'pry'
 module Samwise
   module Util
     def self.duns_is_properly_formatted?(duns: nil)
+      return false if duns.nil?
+
       duns.gsub!('-', '')
 
       return true if duns_contains_forbidden_characters?(duns: duns)

--- a/lib/samwise/version.rb
+++ b/lib/samwise/version.rb
@@ -1,3 +1,3 @@
 module Samwise
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -51,6 +51,12 @@ describe Samwise::Util do
 
       expect(is_formatted).to be(false)
     end
+
+    it 'should return false when the duns number is nil' do
+      is_formatted = Samwise::Util.duns_is_properly_formatted?(duns: nil)
+
+      expect(is_formatted).to be(false)
+    end
   end
 
   context '#format_duns' do


### PR DESCRIPTION
Util.duns_is_properly_formatted? now returns false (instead of erroring) when duns is nil.
