### PR TITLE
Version 0.2.3

### DIFF
--- a/lib/samwise/util.rb
+++ b/lib/samwise/util.rb
@@ -5,7 +5,7 @@ module Samwise
     def self.duns_is_properly_formatted?(duns: nil)
       return false if duns.nil?
 
-      duns.gsub!('-', '')
+      duns = duns.gsub('-', '')
 
       return true if duns_contains_forbidden_characters?(duns: duns)
 
@@ -19,7 +19,7 @@ module Samwise
     def self.format_duns(duns: nil)
       raise Samwise::Error::InvalidFormat unless duns_is_properly_formatted?(duns: duns)
 
-      duns.gsub!('-', '')
+      duns = duns.gsub('-', '')
 
       if duns_is_nine_digits?(duns: duns)
         duns = "#{duns}0000"

--- a/lib/samwise/version.rb
+++ b/lib/samwise/version.rb
@@ -1,3 +1,3 @@
 module Samwise
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -60,6 +60,13 @@ describe Samwise::Util do
   end
 
   context '#format_duns' do
+    it 'should not suffer from mutability side effects' do
+      duns_copy = hyphen_duns.dup
+      Samwise::Util.format_duns(duns: hyphen_duns)
+
+      expect(hyphen_duns).to eq(duns_copy)
+    end
+
     it 'should format an 8 digit DUNS into a 13 digit DUNS' do
       formatted_duns = Samwise::Util.format_duns(duns: eight_duns)
 


### PR DESCRIPTION
Fix mutability bug.

The bug:

```
duns = '08-011-5718'
duns_copy = duns.dup
Samwise::Util.format_duns(duns: hyphen_duns)

expect(hyphen_duns).to eq(duns_copy)
```

However, because of a call to `String.gsub!` in Util,
the original `duns` is modified.

This bug is also propagated into Samwise::Client#duns_is_in_sam?
since it called Samwise::Util::format_duns.

This version bump tests for the bug in Samwise::Util::format_duns
and fixes it.
