### PR TITLE
added is_excluded?

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ client.duns_is_in_sam?(duns: '080037478')
 #=> true
 ```
 
+### Verify Vendor is not on the excluded parties list
+
+```ruby
+client.is_excluded?(duns: '080037478')
+#=> false
+```
+
 ### Get DUNS info
 
 ```ruby

--- a/lib/samwise/client.rb
+++ b/lib/samwise/client.rb
@@ -28,6 +28,11 @@ module Samwise
       JSON.parse(response.body)
     end
 
+    def is_excluded?(duns: nil)
+      response = lookup_duns(duns: duns)
+      JSON.parse(response.body)["hasKnownExclusion"] == false
+    end
+
     private
 
     def lookup_duns(duns: nil)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -113,6 +113,12 @@ describe Samwise::Client, vcr: { cassette_name: "Samwise::Client", record: :new_
         end.to raise_error(Samwise::Error::InvalidFormat)
       end
     end
+  end
 
+  context '#is_excluded?' do
+    it "should verify that vendor in the system is not on the excluded vendor list in sam.gov" do
+      response = client.is_excluded?(duns: nine_duns)
+      expect(response).to be(false)
+    end
   end
 end


### PR DESCRIPTION
The purpose of this commit is to create a method to quickly determine whether a vendor has an exclusion record.

Per https://trello.com/c/yKgfv1dz/94-before-award-confirm-that-the-vendor-is-not-on-the-excluded-parties-list-this-information-should-be-available-in-the-sam-api, I have added this functionality to Samwise. 

cc @adelevie 
