### PR TITLE
Refactor Client#small_business?

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,25 @@ client.excluded?(duns: '080037478')
 ### Verify Vendor is a small business
 
 ```ruby
-client.small_business?(duns: '080037478', naicsCode: 541511)
+client.small_business?(duns: '080037478')
 #=> false
 ```
+
+This method checks against the following NAICS codes:
+
+- 511210
+- 541511
+- 541512
+- 541519
+- 334614
+
+What is a NAICS code?
+
+> The North American Industry Classification System (NAICS) is used by businesses and governments to classify and measure economic activity in the United States, Canada, and Mexico. NAICS is 6-digit code system that is currently the standard used by federal statistical agencies in classifying business establishments.
+
+(source: http://siccode.com/en/pages/what-is-a-naics-code)
+
+The whitelisted NAICS codes classify companies that offer IT or related services.
 
 ### Get DUNS info
 

--- a/lib/samwise/protocol.rb
+++ b/lib/samwise/protocol.rb
@@ -4,6 +4,8 @@ module Samwise
     SAM_API_API_VERSION = 'v4'
     SAM_STATUS_URL      = 'https://www.sam.gov/samdata/registrations/trackProgress'
     SAM_STATUS_KEY      = '1452031543862'
+    NAICS_WHITELIST     = [511210, 541511, 541512, 541519, 334614]
+    FAR_SMALL_BIZ_CITATION  = 'FAR 52.219-1'
 
     def self.duns_url(duns: nil, api_key: nil)
       fail Samwise::Error::ArgumentMissing, 'DUNS number is missing' if duns.nil?

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -126,19 +126,18 @@ describe Samwise::Client, vcr: { cassette_name: "Samwise::Client", record: :new_
   end
 
   context '#small_business?' do
-    it "should verify that vendor in the system is a small business with 5-digit naics code" do
-      response = client.small_business?(duns: nine_duns, naicsCode: naics_code)
-      expect(response).to be(true)
+    context 'the DUNS belongs to a big business' do
+      it 'should return false' do
+        response = client.small_business?(duns: big_biz_duns)
+        expect(response).to be(false)
+      end
     end
 
-    it "should verify that vendor in the system is a small business with full 6-digit naics code" do
-      response = client.small_business?(duns: nine_duns, naicsCode: full_naics_code)
-      expect(response).to be(true)
-    end
-
-    it "should verify that vendor in the system is not a small business" do
-      response = client.small_business?(duns: big_biz_duns, naicsCode: naics_code)
-      expect(response).to be(false)
+    context 'the DUNS belongs to a small business' do
+      it 'should return true' do
+        response = client.small_business?(duns: nine_duns)
+        expect(response).to be(true)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rspec/expectations'
 require 'uri'
 require 'vcr'
 require 'webmock/rspec'
+require 'pry'
 
 
 include Samwise


### PR DESCRIPTION
Rather than pass a NAICS code to `small_business?`,
we check against a whitelist of IT-related NAICS codes.

The whitelist is stored as the constant `Samwise::Protocol::NAICS_WHITELIST`.
